### PR TITLE
Support deserialization from stream

### DIFF
--- a/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
+++ b/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json.Nodes;
 using Azure.Bicep.Types.Concrete;
 using FluentAssertions;
@@ -29,6 +31,20 @@ namespace Azure.Bicep.Types.UnitTests
 
             var serialized = TypeSerializer.Serialize(builtIns);
             var deserializedBuiltIns = TypeSerializer.Deserialize(serialized);
+
+            for (var i = 0; i < builtIns.Length; i++)
+            {
+                deserializedBuiltIns[i].Should().BeOfType<BuiltInType>();
+                var deserializedBuiltIn = (BuiltInType)deserializedBuiltIns[i];
+
+                deserializedBuiltIn.Kind.Should().Be(builtIns[i].Kind);
+            }
+
+            var serializedBytes = Encoding.UTF8.GetBytes(serialized);
+            using (var memoryStream = new MemoryStream(serializedBytes))
+            {
+                deserializedBuiltIns = TypeSerializer.Deserialize(memoryStream);
+            }
 
             for (var i = 0; i < builtIns.Length; i++)
             {

--- a/src/Bicep.Types/TypeSerializer.cs
+++ b/src/Bicep.Types/TypeSerializer.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -35,6 +36,23 @@ namespace Azure.Bicep.Types
             serializeOptions.Converters.Add(new TypeBaseConverter(factory));
 
             var types = JsonSerializer.Deserialize<TypeBase[]>(content, serializeOptions) ?? throw new JsonException("Failed to deserialize content");
+
+            factory.Hydrate(types);
+
+            return types;
+        }
+
+        public static TypeBase[] Deserialize(Stream contentStream)
+        {
+            var factory = new TypeFactory(Enumerable.Empty<TypeBase>());
+
+            var serializeOptions = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            };
+            serializeOptions.Converters.Add(new TypeBaseConverter(factory));
+
+            var types = JsonSerializer.Deserialize<TypeBase[]>(contentStream, serializeOptions) ?? throw new JsonException("Failed to deserialize content");
 
             factory.Hydrate(types);
 


### PR DESCRIPTION
By supporting stream here in Azure.Bicep.Types.Az.TypeLoader.LoadType we can deserialize directly from deflate stream instead of allocating a string to pass it here.