### PR TITLE
Fix nullability for optional typeindex properties

### DIFF
--- a/src/Bicep.Types/Index/TypeIndex.cs
+++ b/src/Bicep.Types/Index/TypeIndex.cs
@@ -9,8 +9,8 @@ namespace Azure.Bicep.Types.Index
         public TypeIndex(
             IReadOnlyDictionary<string, CrossFileTypeReference> resources,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyList<CrossFileTypeReference>>> resourceFunctions,
-            TypeSettings settings,
-            CrossFileTypeReference fallbackResourceType)
+            TypeSettings? settings,
+            CrossFileTypeReference? fallbackResourceType)
         {
             Resources = resources;
             ResourceFunctions = resourceFunctions;


### PR DESCRIPTION
Fortunately this doesn't seem to cause any deserialization errors, but it would be good to correct regardless.