### PR TITLE
Dedupe

### DIFF
--- a/src/Bicep.Types.UnitTests/Bicep.Types.UnitTests.csproj
+++ b/src/Bicep.Types.UnitTests/Bicep.Types.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Bicep.Types.UnitTests/packages.lock.json
+++ b/src/Bicep.Types.UnitTests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net8.0": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[6.0.2, )",
@@ -65,7 +65,6 @@
         "resolved": "9.0.0",
         "contentHash": "CxUGXLXdbG7hxdQCRdxQKwq//OtYfxKsKyy6oYjSr9zpSvza5rW9TxokNasSLfmETRKDTfu1zqW8RQKokyKw/Q==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Text.Json": "9.0.0"
         }
       },
@@ -76,11 +75,6 @@
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "9.0.0",
-        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -166,11 +160,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -196,27 +185,12 @@
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "9.0.0",
-        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
+        "contentHash": "eA3cinogwaNB4jdjQHOP3Z3EuyiDII7MT35jgtnsA4vkn0LUrrSHsU0nzHTzFzmaFYeKV7MYyMxOocFzsBHpTw=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
         "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -240,31 +214,16 @@
       "System.Text.Encodings.Web": {
         "type": "Transitive",
         "resolved": "9.0.0",
-        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "contentHash": "e2hMgAErLbKyUUwt18qSBf9T5Y+SFAL3ZedM8fLupkVj8Rj2PZ9oxQ37XX2LF8fTO1wNIxvKpihD7Of7D/NxZw=="
       },
       "System.Text.Json": {
         "type": "Transitive",
         "resolved": "9.0.0",
         "contentHash": "js7+qAu/9mQvnhA4EfGMZNEzXtJCDxgkgj8ohuxq/Qxv+R56G+ljefhiJHOxTNiw54q8vmABCWUwkMulNdlZ4A==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
-          "System.Buffers": "4.5.1",
           "System.IO.Pipelines": "9.0.0",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Text.Encodings.Web": "9.0.0"
         }
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "System.Windows.Extensions": {
         "type": "Transitive",

--- a/src/bicep-types/src/writers/markdown.ts
+++ b/src/bicep-types/src/writers/markdown.ts
@@ -174,7 +174,7 @@ export function writeMarkdown(types: BicepType[], fileHeading?: string) {
 
   function writeFunctionType(name: string, functionType: FunctionType, nesting: number) {
     md.writeHeading(nesting, `Function ${name}`);
-    
+
     md.writeBullet("Output", getTypeName(types, functionType.output));
 
     md.writeHeading(nesting + 1, "Parameters");
@@ -268,6 +268,49 @@ export function writeMarkdown(types: BicepType[], fileHeading?: string) {
     }
   }
 
+  function isComplexType(type: BicepType) {
+    switch (type.type) {
+      case TypeBaseKind.ResourceType:
+      case TypeBaseKind.ResourceFunctionType:
+      case TypeBaseKind.ObjectType:
+      case TypeBaseKind.DiscriminatedObjectType:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function getComplexTypeName(type: BicepType) {
+    switch (type.type) {
+      case TypeBaseKind.ResourceType:
+        return (type as ResourceType).name;
+      case TypeBaseKind.ResourceFunctionType:
+        return (type as ResourceFunctionType).name;
+      case TypeBaseKind.ObjectType:
+        return (type as ObjectType).name;
+      case TypeBaseKind.DiscriminatedObjectType:
+        return (type as DiscriminatedObjectType).name;
+      default:
+        return undefined;
+    }
+  }
+
+  function dedupeAndFilter(typesToWrite: BicepType[]) {
+    const uniqueTypesMap = new Map<string, BicepType>();
+
+    for (const type of typesToWrite) {
+      if (isComplexType(type)) {
+        const typeName = getComplexTypeName(type);
+
+        if (typeName && !uniqueTypesMap.has(typeName)) {
+          uniqueTypesMap.set(typeName, type);
+        }
+      }
+    }
+
+    return Array.from(uniqueTypesMap.values());
+  }
+
   function generateMarkdown(types: BicepType[]) {
     md.writeHeading(1, fileHeading ?? 'Bicep Types');
     md.writeNewLine();
@@ -290,7 +333,9 @@ export function writeMarkdown(types: BicepType[], fileHeading?: string) {
       findTypesToWrite(types, typesToWrite, resourceFunctionType.output);
     }
 
-    typesToWrite.sort((a, b) => {
+    const complexTypesToWrite = dedupeAndFilter(typesToWrite);
+
+    complexTypesToWrite.sort((a, b) => {
       const aName = (a as ObjectType).name?.toLowerCase();
       const bName = (b as ObjectType).name?.toLowerCase();
 
@@ -302,7 +347,7 @@ export function writeMarkdown(types: BicepType[], fileHeading?: string) {
       return 0;
     });
 
-    for (const type of (resourceTypes as BicepType[]).concat(resourceFunctionTypes).concat(typesToWrite)) {
+    for (const type of (resourceTypes as BicepType[]).concat(resourceFunctionTypes).concat(complexTypesToWrite)) {
       writeComplexType(types, type, 2, true);
     }
 


### PR DESCRIPTION
The generated markdown files could have duplicate types. For example, in [ApiManagement](https://github.com/Azure/bicep-types-az/blob/main/generated/apimanagement/microsoft.apimanagement/2024-06-01-preview/types.md), the following types are written more than once:

`ClientSecretContract`
`NamedValueSecretContract`

This PR adds dedupe logic using object reference. There will still be duplicate types like below; but they come from `types.json` files. It will be addressed separately.

`ParameterExamplesContract` (it has duplicate definitions in [types.json](https://github.com/Azure/bicep-types-az/blob/main/generated/apimanagement/microsoft.apimanagement/2024-06-01-preview/types.json))