### PR TITLE
Add isPreview and isDeprecated type index settings

### DIFF
--- a/src/Bicep.Types/Index/TypeSettings.cs
+++ b/src/Bicep.Types/Index/TypeSettings.cs
@@ -9,14 +9,25 @@ namespace Azure.Bicep.Types.Index
     public class TypeSettings
     {
         [JsonConstructor]
-        public TypeSettings(string name, string version, bool isSingleton, CrossFileTypeReference configurationType)
-            => (Name, Version, IsSingleton, ConfigurationType) = (name, version, isSingleton, configurationType);
+        public TypeSettings(string name, string version, bool isSingleton, bool? isPreview = false, bool? isDeprecated = false, CrossFileTypeReference? configurationType = null)
+        {
+            this.Name = name;
+            this.Version = version;
+            this.IsSingleton = isSingleton;
+            this.IsPreview = isPreview;
+            this.IsDeprecated = isDeprecated;
+            this.ConfigurationType = configurationType;
+        }
 
         public string Name { get; }
 
         public string Version { get; }
 
         public bool IsSingleton { get; }
+
+        public bool? IsPreview { get; }
+
+        public bool? IsDeprecated { get; }
 
         public CrossFileTypeReference? ConfigurationType { get; }
     }

--- a/src/bicep-types/src/types.ts
+++ b/src/bicep-types/src/types.ts
@@ -416,5 +416,7 @@ export interface TypeSettings {
   name: string;
   version: string;
   isSingleton: boolean;
+  isPreview?: boolean;
+  isDeprecated?: boolean;
   configurationType?: CrossFileTypeReference;
 }

--- a/src/bicep-types/test/integration/baselines/foo/index.json
+++ b/src/bicep-types/test/integration/baselines/foo/index.json
@@ -8,6 +8,8 @@
   "settings": {
     "name": "Foo",
     "isSingleton": true,
+    "isPreview": true,
+    "isDeprecated": false,
     "version": "0.1.2",
     "configurationType": {
       "$ref": "types.json#/0"

--- a/src/bicep-types/test/integration/types.test.ts
+++ b/src/bicep-types/test/integration/types.test.ts
@@ -73,10 +73,12 @@ describe('types tests', () => {
         description: 'Body property',
       },
     }), ResourceFlags.None);
-    
+
     const settings: TypeSettings = {
       name: 'Foo',
       isSingleton: true,
+      isPreview: true,
+      isDeprecated: false,
       version: '0.1.2',
       configurationType: new CrossFileTypeReference('types.json', configLocation.index),
     };


### PR DESCRIPTION
Added `isPreview` to support the Kubernetes v2 extension type generation. Included `isDeprecated `preemptively for potential future use.