### PR TITLE
Add `WriteOnly` resource flag

### DIFF
--- a/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
+++ b/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
@@ -177,6 +177,31 @@ namespace Azure.Bicep.Types.UnitTests
             ((ResourceType)deserialized[1]).ReadOnlyScopes.HasValue.Should().Be(false);
         }
 
+        [TestMethod]
+        public void Resource_with_writeonly_flag_can_be_deserialized()
+        {
+            var factory = new TypeFactory(Enumerable.Empty<TypeBase>());
+            var objectType = factory.Create(() => new ObjectType("testObject", new Dictionary<string, ObjectTypeProperty>(), null));
+            var resourceType = factory.Create(() => new ResourceType(
+                "testResource",
+                ScopeType.ResourceGroup,
+                null,
+                factory.GetReference(objectType),
+                ResourceFlags.WriteOnly,
+                null));
+
+            using var stream = BuildStream(s => TypeSerializer.Serialize(s, factory.GetTypes()));
+            var deserialized = TypeSerializer.Deserialize(stream);
+
+            deserialized[0].Should().BeOfType<ObjectType>();
+            deserialized[1].Should().BeOfType<ResourceType>();
+
+            ((ObjectType)deserialized[0]).Name.Should().Be(objectType.Name);
+            ((ResourceType)deserialized[1]).Name.Should().Be(resourceType.Name);
+            ((ResourceType)deserialized[1]).Flags.Should().Be(ResourceFlags.WriteOnly);
+            ((ResourceType)deserialized[1]).ReadOnlyScopes.HasValue.Should().Be(false);
+        }
+
         private static Stream BuildStream(Action<Stream> writeFunc)
         {
             var memoryStream = new MemoryStream();

--- a/src/Bicep.Types/Concrete/ResourceType.cs
+++ b/src/Bicep.Types/Concrete/ResourceType.cs
@@ -12,6 +12,7 @@ namespace Azure.Bicep.Types.Concrete
     {
         None = 0,
         ReadOnly = 1 << 0,
+        WriteOnly = 1 << 0,
     }
 
     public class ResourceType : TypeBase

--- a/src/Bicep.Types/Concrete/ResourceType.cs
+++ b/src/Bicep.Types/Concrete/ResourceType.cs
@@ -12,7 +12,7 @@ namespace Azure.Bicep.Types.Concrete
     {
         None = 0,
         ReadOnly = 1 << 0,
-        WriteOnly = 1 << 0,
+        WriteOnly = 1 << 1,
     }
 
     public class ResourceType : TypeBase

--- a/src/bicep-types/src/types.ts
+++ b/src/bicep-types/src/types.ts
@@ -113,10 +113,12 @@ export function getTypeBaseKindLabel(input: TypeBaseKind): string {
 export enum ResourceFlags {
   None = 0,
   ReadOnly = 1 << 0,
+  WriteOnly = 1 << 1,
 }
 
 const ResourceFlagsLabels = new Map<ResourceFlags, string>([
   [ResourceFlags.ReadOnly, 'ReadOnly'],
+  [ResourceFlags.WriteOnly, 'WriteOnly'],
 ]);
 
 export function getResourceFlagsLabels(input: ResourceFlags) {


### PR DESCRIPTION
Certain extensions are write-only by design, to support this a `WriteOnly` flag has been added to ResourceFlags. This allows an extension to mark certain resource types as write-only, without requiring all types to be write-only.