### PR TITLE
[AOT compliance] Using JsonSerializer.Deserialize overload that takes JsonTypeInfo

### DIFF
--- a/src/Bicep.Types/Serialization/TypeSerializer.cs
+++ b/src/Bicep.Types/Serialization/TypeSerializer.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Bicep.Types.Concrete;
 using Azure.Bicep.Types.Index;
 
@@ -35,6 +34,9 @@ public static class TypeSerializer
         JsonSerializer.Serialize(stream, types, options);
     }
 
+    [SuppressMessage("Trimming", 
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", 
+        Justification = "TypeBase[] is included in TypeJsonContext via [JsonSerializable(typeof(TypeBase[]))], providing required type metadata for trimming-safe serialization.")]
     public static TypeBase[] Deserialize(Stream contentStream)
     {
         var factory = new TypeFactory(Enumerable.Empty<TypeBase>());
@@ -48,6 +50,9 @@ public static class TypeSerializer
         return types;
     }
 
+    [SuppressMessage("Trimming", 
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", 
+        Justification = "TypeIndex is included in TypeJsonContext via [JsonSerializable(typeof(TypeIndex))], providing required type metadata for trimming-safe serialization.")]
     public static TypeIndex DeserializeIndex(Stream contentStream)
     {
         var options = GetSerializerOptions();


### PR DESCRIPTION
There are two AOT IL2026 warnings from Azure.Bicep.Types library -

```
  "Azure.Bicep.Types.dll": [
    "ILLink : Trim analysis warning IL2026: Azure.Bicep.Types.Serialization.TypeSerializer.Deserialize(Stream): Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [/mnt/vss/_work/1/s/src/AzureMcp.csproj]",
    "ILLink : Trim analysis warning IL2026: Azure.Bicep.Types.Serialization.TypeSerializer.DeserializeIndex(Stream): Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [/mnt/vss/_work/1/s/src/AzureMcp.csproj]"
  ],
```


This pr updates the flagged call sites to use the [overload](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer.deserialize?view=net-9.0#system-text-json-jsonserializer-deserialize-1(system-readonlyspan((system-byte))-system-text-json-serialization-metadata-jsontypeinfo((-0)))) of `JsonSerializer.Deserialize` that takes `JsonTypeInfo`.