### PR TITLE
Add `Readable Scopes` & `Writable Scopes` to markdown file generation

### DIFF
--- a/src/bicep-types/src/writers/markdown.ts
+++ b/src/bicep-types/src/writers/markdown.ts
@@ -192,11 +192,8 @@ export function writeMarkdown(types: BicepType[], fileHeading?: string) {
       case TypeBaseKind.ResourceType: {
         const resourceType = type as ResourceType;
         md.writeHeading(nesting, `Resource ${resourceType.name}`);
-        md.writeBullet(
-          "Valid Scope(s)",
-          getScopeTypeLabels(resourceType.writableScopes | resourceType.readableScopes, [resourceType.readableScopes & ~resourceType.writableScopes, "ReadOnly"])
-            .join(", ") || "Unknown"
-        );
+        md.writeBullet("Readable Scope(s)", getScopeTypeLabels(resourceType.readableScopes).join(", ") || "None");
+        md.writeBullet("Writable Scope(s)", getScopeTypeLabels(resourceType.writableScopes).join(", ") || "None");
         writeComplexType(types, types[resourceType.body.index], nesting, false);
 
         if (resourceType.functions) {

--- a/src/bicep-types/test/integration/baselines/foo/foo/types.md
+++ b/src/bicep-types/test/integration/baselines/foo/foo/types.md
@@ -1,7 +1,8 @@
 # Bicep Types
 
 ## Resource foo@v1
-* **Valid Scope(s)**: Unknown
+* **Readable Scope(s)**: None
+* **Writable Scope(s)**: None
 ### Properties
 * **abc**: string: Abc prop
 * **arrayType**: any[] {minLength: 1, maxLength: 10}: Array of any

--- a/src/bicep-types/test/integration/baselines/foo/types.md
+++ b/src/bicep-types/test/integration/baselines/foo/types.md
@@ -1,7 +1,8 @@
 # Bicep Types
 
 ## Resource fallback
-* **Valid Scope(s)**: Unknown
+* **Readable Scope(s)**: None
+* **Writable Scope(s)**: None
 ### Properties
 * **bodyProp**: [config](#config) (Required): Body property
 

--- a/src/bicep-types/test/integration/baselines/http/http/v1/types.md
+++ b/src/bicep-types/test/integration/baselines/http/http/v1/types.md
@@ -1,7 +1,8 @@
 # Bicep Types
 
 ## Resource request@v1
-* **Valid Scope(s)**: Unknown
+* **Readable Scope(s)**: None
+* **Writable Scope(s)**: None
 ### Properties
 * **body**: any (ReadOnly): The parsed request body.
 * **format**: 'json' | 'raw': How to deserialize the response body.

--- a/src/bicep-types/test/integration/types.test.ts
+++ b/src/bicep-types/test/integration/types.test.ts
@@ -121,7 +121,7 @@ describe('types tests', () => {
       "modern@v1",
       obj,
       ScopeType.ResourceGroup | ScopeType.Subscription,
-      ScopeType.ResourceGroup,
+      ScopeType.ManagementGroup,
     );
 
     const json = writeTypesJson(f.types);
@@ -135,8 +135,9 @@ describe('types tests', () => {
     expect(resJson.flags).toBeUndefined();
 
     const md = writeMarkdown(f.types);
-    expect(md).toMatch(/Valid Scope\(s\).*ResourceGroup/);
-    expect(md).toMatch(/Valid Scope\(s\).*Subscription/);
+    expect(md).toMatch(/Readable Scope\(s\).*ResourceGroup/);
+    expect(md).toMatch(/Readable Scope\(s\).*Subscription/);
+    expect(md).toMatch(/Writable Scope\(s\).*ManagementGroup/);
   });
 
   it('addUnscopedResourceType maps boolean parameters correctly', () => {


### PR DESCRIPTION
This PR adds readable scopes & writable sopes to types.md files