### PR TITLE
Add `ScopeType.All` and fix legacy scopeType 0 mapping

### DIFF
--- a/src/Bicep.Types.UnitTests/BaselineTests.cs
+++ b/src/Bicep.Types.UnitTests/BaselineTests.cs
@@ -52,7 +52,7 @@ public class BaselineTests
         GetBaselinePaths().Should().Contain(x => (string)x[0] == "foo");
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DynamicData(nameof(GetBaselinePaths), DynamicDataSourceType.Method)]
     public void TypeLoader_can_load_all_types_without_throwing(string baselineName)
     {

--- a/src/Bicep.Types.UnitTests/Bicep.Types.UnitTests.csproj
+++ b/src/Bicep.Types.UnitTests/Bicep.Types.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="8.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+  <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageReference Include="System.Memory.Data" Version="9.0.9" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
+++ b/src/Bicep.Types.UnitTests/TypeSerializerTests.cs
@@ -383,9 +383,9 @@ namespace Azure.Bicep.Types.UnitTests
         }
 
         [TestMethod]
-        public void ResourceType_with_legacy_unknown_scope_deserializes_as_all_except_extension()
+        public void ResourceType_with_legacy_unknown_scope_deserializes_as_all()
         {
-            // This test verifies that legacy ScopeType.Unknown (value 0) is remapped to AllExceptExtension
+            // This test verifies that legacy ScopeType.Unknown (value 0) is remapped to ScopeType.All (all scopes including extension)
             var json = @"[
                 {
                     ""$type"": ""ObjectType"",
@@ -409,9 +409,9 @@ namespace Azure.Bicep.Types.UnitTests
             var deserialized = TypeSerializer.Deserialize(stream);
             var deserializedResource = deserialized.OfType<ResourceType>().Single();
             
-            // Legacy ScopeType.Unknown (0) should be interpreted as AllExceptExtension for backward compatibility
-            deserializedResource.ReadableScopes.Should().Be(ScopeType.AllExceptExtension);
-            deserializedResource.WritableScopes.Should().Be(ScopeType.AllExceptExtension);
+            // Legacy ScopeType.Unknown (0) should be interpreted as All for backward compatibility
+            deserializedResource.ReadableScopes.Should().Be(ScopeType.All);
+            deserializedResource.WritableScopes.Should().Be(ScopeType.All);
         }
 
         private static Stream BuildStream(Action<Stream> writeFunc)

--- a/src/Bicep.Types.UnitTests/packages.lock.json
+++ b/src/Bicep.Types.UnitTests/packages.lock.json
@@ -46,11 +46,11 @@
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[3.7.3, )",
-        "resolved": "3.7.3",
-        "contentHash": "Eg4F4zOsAFKlSiLI3tOJfg6BGXeppLhgdupAfVlnpZBXa3rNqxINIeZDJ5/KpoW5BRZyUSZW76Q8yNNk0GqCEQ==",
+        "requested": "[3.10.4, )",
+        "resolved": "3.10.4",
+        "contentHash": "i6P4/1d2Nc4O5eOcTfvjqc/psgNNuyfMPNNU3cTvQe56bznykTZ1X88eB8JmYa+V3UiTTBKXyDP9yUb8oezLoQ==",
         "dependencies": {
-          "MSTest.Analyzers": "3.7.3"
+          "MSTest.Analyzers": "3.10.4"
         }
       },
       "Nerdbank.GitVersioning": {
@@ -157,8 +157,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.7.3",
-        "contentHash": "5KcyyxIP0UBRKBs135+S3JQJALc1PmZMzhpR86JIXQ2Dnd/lDiOGNDD8R23X015mWi1K95KQWsGWw+3e7DUrgg=="
+        "resolved": "3.10.4",
+        "contentHash": "a3IHTsbd+iS0pZUI7KC6nCCQgTOhjPyqDwPOtKLGCwjRifQ9N4K40qTqCaQlPOxwKaIxVwDLRYFvdY9NTDVi0w=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/src/Bicep.Types/Concrete/ResourceType.cs
+++ b/src/Bicep.Types/Concrete/ResourceType.cs
@@ -56,12 +56,12 @@ namespace Azure.Bicep.Types.Concrete
                 // Derive modern properties from legacy input (format normalization)
                 var effectiveScopeType = scopeType ?? Azure.Bicep.Types.Concrete.ScopeType.None;
 
-                // Legacy: 'Unknown' value (0) meant "all standard scopes"
-                // Now the value 0 maps to ScopeType.None which is restrictive
-                // To preserve legacy intent, if an explicit legacy scopeType of 0 is provided then interpret as AllExceptExtension
+                // Legacy: 'Unknown' value (0) historically meant "valid at any scope (including extension)".
+                // Value 0 now numerically maps to ScopeType.None. For backward compatibility,
+                // Remap explicit legacy 0 to ScopeType.All (AllExceptExtension | Extension).
                 if (scopeType.HasValue && scopeType.Value == Azure.Bicep.Types.Concrete.ScopeType.None)
                 {
-                    effectiveScopeType = Azure.Bicep.Types.Concrete.ScopeType.AllExceptExtension;
+                    effectiveScopeType = Azure.Bicep.Types.Concrete.ScopeType.All;
                 }
 
                 ReadableScopes = effectiveScopeType;

--- a/src/Bicep.Types/Concrete/ResourceType.cs
+++ b/src/Bicep.Types/Concrete/ResourceType.cs
@@ -56,6 +56,14 @@ namespace Azure.Bicep.Types.Concrete
                 // Derive modern properties from legacy input (format normalization)
                 var effectiveScopeType = scopeType ?? Azure.Bicep.Types.Concrete.ScopeType.None;
 
+                // Legacy: 'Unknown' value (0) meant "all standard scopes"
+                // Now the value 0 maps to ScopeType.None which is restrictive
+                // To preserve legacy intent, if an explicit legacy scopeType of 0 is provided then interpret as AllExceptExtension
+                if (scopeType.HasValue && scopeType.Value == Azure.Bicep.Types.Concrete.ScopeType.None)
+                {
+                    effectiveScopeType = Azure.Bicep.Types.Concrete.ScopeType.AllExceptExtension;
+                }
+
                 ReadableScopes = effectiveScopeType;
                 if (readOnlyScopes.HasValue)
                 {

--- a/src/Bicep.Types/Concrete/ScopeType.cs
+++ b/src/Bicep.Types/Concrete/ScopeType.cs
@@ -20,5 +20,7 @@ namespace Azure.Bicep.Types.Concrete
         Extension = 1 << 4,
 
         AllExceptExtension = Tenant | ManagementGroup | Subscription | ResourceGroup,
+
+        All = AllExceptExtension | Extension,
     }
 }

--- a/src/bicep-types/src/types.ts
+++ b/src/bicep-types/src/types.ts
@@ -37,6 +37,7 @@ export enum ScopeType {
 }
 
 export const AllExceptExtension = ScopeType.Tenant | ScopeType.ManagementGroup | ScopeType.Subscription | ScopeType.ResourceGroup;
+export const All = AllExceptExtension | ScopeType.Extension;
 
 const ScopeTypeLabel = new Map<ScopeType, string>([
   [ScopeType.Tenant, 'Tenant'],
@@ -346,8 +347,8 @@ export class TypeFactory {
     writable: boolean = true,
     functions?: Record<string, ResourceTypeFunction>,
   ): TypeReference {
-    const readableScopes = readable ? AllExceptExtension : ScopeType.None;
-    const writableScopes = writable ? AllExceptExtension : ScopeType.None;
+  const readableScopes = readable ? All : ScopeType.None;
+  const writableScopes = writable ? All : ScopeType.None;
 
     const resource: ResourceType = {
       type: TypeBaseKind.ResourceType,

--- a/src/bicep-types/test/integration/types.test.ts
+++ b/src/bicep-types/test/integration/types.test.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 import { existsSync } from 'fs';
 import { mkdir, writeFile, readFile } from 'fs/promises';
-import { CrossFileTypeReference, FunctionParameter, ObjectTypePropertyFlags, ScopeType, TypeFactory, TypeFile, TypeIndex, TypeSettings, ResourceType, AllExceptExtension } from '../../src/types';
+import { CrossFileTypeReference, FunctionParameter, ObjectTypePropertyFlags, ScopeType, TypeFactory, TypeFile, TypeIndex, TypeSettings, ResourceType, AllExceptExtension, All } from '../../src/types';
 import { readTypesJson, writeIndexJson, writeTypesJson } from '../../src/writers/json';
 import { writeIndexMarkdown, writeMarkdown } from '../../src/writers/markdown';
 import { buildIndex } from '../../src/indexer';
@@ -150,16 +150,16 @@ describe('types tests', () => {
     const neither = factory.addUnscopedResourceType('test4@v1', body, false, false);
 
     const resource1 = factory.lookupType(readableWritable) as ResourceType;
-    expect(resource1.readableScopes).toBe(AllExceptExtension);
-    expect(resource1.writableScopes).toBe(AllExceptExtension);
+  expect(resource1.readableScopes).toBe(All);
+  expect(resource1.writableScopes).toBe(All);
 
     const resource2 = factory.lookupType(readableOnly) as ResourceType;
-    expect(resource2.readableScopes).toBe(AllExceptExtension);
+  expect(resource2.readableScopes).toBe(All);
     expect(resource2.writableScopes).toBe(ScopeType.None);
 
     const resource3 = factory.lookupType(writableOnly) as ResourceType;
     expect(resource3.readableScopes).toBe(ScopeType.None);
-    expect(resource3.writableScopes).toBe(AllExceptExtension);
+  expect(resource3.writableScopes).toBe(All);
 
     const resource4 = factory.lookupType(neither) as ResourceType;
     expect(resource4.readableScopes).toBe(ScopeType.None);
@@ -173,8 +173,8 @@ describe('types tests', () => {
     const defaultBehavior = factory.addUnscopedResourceType('testDefaults@v1', body);
 
     const resource = factory.lookupType(defaultBehavior) as ResourceType;
-    expect(resource.readableScopes).toBe(AllExceptExtension);
-    expect(resource.writableScopes).toBe(AllExceptExtension);
+  expect(resource.readableScopes).toBe(All);
+  expect(resource.writableScopes).toBe(All);
   });
 });
  


### PR DESCRIPTION
ScopeType.Unknown was renamed to ScopeType.None in a previous PR. However, the behaviour has changed, Unknown allows all scopes while None restricts any scope. 

To fix this, if the scope properties are legacy and the enum value is 0 then set the effectiveScopeType to ScopeType.All. 